### PR TITLE
Fix cache stop using context cancel

### DIFF
--- a/gitcache/gitcache.go
+++ b/gitcache/gitcache.go
@@ -26,6 +26,7 @@ type GitCache struct {
 
 	running bool
 	ctx     context.Context
+	cancel  context.CancelFunc
 	cmu     sync.RWMutex
 }
 
@@ -61,12 +62,14 @@ type repoBranchInfo struct {
 }
 
 func NewGitCache(cfg *config.Config, ctx context.Context, manager GitCacheManager) *GitCache {
+	ctx, cancel := context.WithCancel(ctx)
 	return &GitCache{
 		cfg:        cfg,
 		tokenCache: ccache.New(ccache.Configure().MaxSize(10000000)),
 		repos:      make(map[string]*gitRepo),
 		manager:    manager,
 		ctx:        ctx,
+		cancel:     cancel,
 	}
 }
 

--- a/gitcache/gitcache_service.go
+++ b/gitcache/gitcache_service.go
@@ -37,7 +37,7 @@ func (c *GitCache) Stop() {
 	if !c.IsRunning() {
 		return
 	}
-	c.ctx.Done()
+	c.cancel()
 	c.tokenCache.Stop()
 }
 


### PR DESCRIPTION
## Summary
- fix Stop() by canceling the GitCache context
- store cancel function when creating a new GitCache

## Testing
- `go test ./...` *(fails: no route to host)*